### PR TITLE
Add external images docs and layout patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+examples/

--- a/docs/images/external-images.md
+++ b/docs/images/external-images.md
@@ -1,0 +1,242 @@
+# External Images (ControlType 101)
+
+Display external images from the local filesystem with optional auto-refresh. Used for security cameras, album art, timetables, and any dynamically updating content.
+
+> **Verified against working .textClipping exports from production Indigo installations.**
+
+---
+
+## Overview
+
+Unlike standard device controls that use `ImageFileName` to reference built-in Indigo images, ControlType 101 elements use `ImageFileURL` to load images from any `file:///` path on the Indigo server. Combined with `ImageRefreshDuration`, this creates live-updating displays.
+
+---
+
+## Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `ControlType` | integer | Yes | Must be `101` |
+| `ImageFileURL` | string | Yes | `file:///` URL to the image on disk |
+| `ImageRefreshDuration` | integer | No | Auto-refresh interval in milliseconds (e.g., `1000` = 1 second) |
+| `Size` | string | Yes | Element dimensions `"width height"` — typically matches the image or page size |
+| `Position` | string | Yes | `"X Y"` position. Negative values are valid (see Layout Notes) |
+| `ShowStateImage` | bool | No | Usually `true` for external images |
+| `ShowStateText` | bool | No | Usually `false` |
+
+**Note:** `ImageFileURL` is used **instead of** `ImageFileName`. Do not use both on the same element.
+
+---
+
+## Common Refresh Intervals
+
+| Use Case | Duration (ms) | Notes |
+|----------|---------------|-------|
+| Security camera | `1000` | 1 second — near real-time feed |
+| Album art | `1000`–`4000` | Updates when track changes |
+| Timetable / schedule | `30000` | 30 seconds — data changes infrequently |
+| Static display | omit | No refresh needed |
+
+---
+
+## Anchor Element Pattern
+
+Pages using external images commonly start with a small anchor element followed by a status text display. This pattern appears consistently across working examples:
+
+```xml
+<!-- 1. Tiny anchor element (18x18 icon indicator at top-left) -->
+<PageElem type="dict">
+	<ActionGroup type="dict">
+		<ActionSteps type="vector">
+		</ActionSteps>
+		<ObjVers type="integer">2</ObjVers>
+	</ActionGroup>
+	<CaptionPlacement type="integer">4</CaptionPlacement>
+	<ControlType type="integer">201</ControlType>
+	<ObjVers type="integer">9</ObjVers>
+	<Position type="string">2 2</Position>
+	<ShowStateImage type="bool">true</ShowStateImage>
+	<ShowStateText type="bool">false</ShowStateText>
+	<Size type="string">18 18</Size>
+	<StateTextAlignment type="integer">0</StateTextAlignment>
+</PageElem>
+
+<!-- 2. Status text display -->
+<PageElem type="dict">
+	<ActionGroup type="dict">
+		<ActionSteps type="vector">
+		</ActionSteps>
+		<ObjVers type="integer">2</ObjVers>
+	</ActionGroup>
+	<CaptionCurHeight type="integer">13</CaptionCurHeight>
+	<CaptionCurWidth type="integer">35</CaptionCurWidth>
+	<CaptionName type="string">status:</CaptionName>
+	<CaptionPlacement type="integer">4</CaptionPlacement>
+	<CaptionWraps type="bool">false</CaptionWraps>
+	<ControlType type="integer">200</ControlType>
+	<ObjVers type="integer">9</ObjVers>
+	<Position type="string">61 4</Position>
+	<ShowStateImage type="bool">false</ShowStateImage>
+	<ShowStateText type="bool">true</ShowStateText>
+	<Size type="string">364 13</Size>
+	<StateTextAlignment type="integer">0</StateTextAlignment>
+</PageElem>
+```
+
+---
+
+## Examples
+
+### Full-Screen Image (Train Timetable)
+
+iPhone-sized page displaying an auto-refreshing timetable image. The element fills the entire page.
+
+Source: verified working Walton-Waterloo .textClipping export.
+
+```xml
+<ControlPageList type="vector">
+<ControlPage type="dict">
+	<Category type="integer">0</Category>
+	<ID type="integer">1624687364</ID>
+	<Name type="string">Walton-Waterloo</Name>
+	<ObjVers type="integer">5</ObjVers>
+	<Size type="string">414 844</Size>
+	<PageElemList type="vector">
+		<PageElem type="dict">
+			<ActionGroup type="dict">
+				<ActionSteps type="vector">
+					<Action type="dict">
+						<Class type="integer">0</Class>
+						<ObjVers type="integer">14</ObjVers>
+					</Action>
+				</ActionSteps>
+				<ObjVers type="integer">2</ObjVers>
+			</ActionGroup>
+			<CaptionPlacement type="integer">1</CaptionPlacement>
+			<ControlType type="integer">101</ControlType>
+			<ImageFileURL type="string">file:////Users/simon/Documents/iTravel/WALWATtimetable_mobile.png</ImageFileURL>
+			<ImageRefreshDuration type="integer">30000</ImageRefreshDuration>
+			<ObjVers type="integer">9</ObjVers>
+			<Position type="string">0 -1</Position>
+			<ShowStateImage type="bool">true</ShowStateImage>
+			<ShowStateText type="bool">false</ShowStateText>
+			<Size type="string">414 844</Size>
+		</PageElem>
+	</PageElemList>
+</ControlPage>
+</ControlPageList>
+```
+
+**Key points:**
+- Element `Size` matches page `Size` (`414 844`) for full-screen display
+- `Position: 0 -1` — slight negative Y offset is common for precise alignment
+- `ImageRefreshDuration: 30000` — refreshes every 30 seconds
+- No `Color` property on the page — the image covers everything
+
+### Security Camera Feed (Landscape)
+
+Large landscape page for a mounted display showing a security camera.
+
+Source: verified working Drive Cam .textClipping export.
+
+```xml
+<ControlPageList type="vector">
+<ControlPage type="dict">
+	<Category type="integer">0</Category>
+	<Color type="string">CA CA CA</Color>
+	<ID type="integer">1365672249</ID>
+	<Name type="string">Drive Cam</Name>
+	<ObjVers type="integer">5</ObjVers>
+	<Size type="string">1024 600</Size>
+	<PageElemList type="vector">
+		<!-- anchor + status elements omitted for brevity -->
+		<PageElem type="dict">
+			<ActionGroup type="dict">
+				<ActionSteps type="vector">
+					<Action type="dict">
+						<Class type="integer">0</Class>
+						<ObjVers type="integer">14</ObjVers>
+					</Action>
+				</ActionSteps>
+				<ObjVers type="integer">2</ObjVers>
+			</ActionGroup>
+			<ControlType type="integer">101</ControlType>
+			<ImageFileURL type="string">file:///Volumes/Recordings/SecuritySpy/Drive Cam.jpg</ImageFileURL>
+			<ImageRefreshDuration type="integer">1000</ImageRefreshDuration>
+			<ObjVers type="integer">9</ObjVers>
+			<Position type="string">51 -39</Position>
+			<ShowStateImage type="bool">true</ShowStateImage>
+			<ShowStateText type="bool">false</ShowStateText>
+			<Size type="string">1000 600</Size>
+			<TargetElemSubKey type="string">sensorValue</TargetElemSubKey>
+		</PageElem>
+	</PageElemList>
+</ControlPage>
+</ControlPageList>
+```
+
+**Key points:**
+- `ImageRefreshDuration: 1000` — 1-second refresh for near real-time camera feed
+- Light gray background (`CA CA CA`) visible around the image edges
+- Element slightly larger positioning with `Position: 51 -39` — negative Y shifts image up
+- JPG format works — not limited to PNG for external images
+
+### Album Art with Media Controls (Sonos)
+
+Wide landscape page with two album art panels and transport controls.
+
+Source: verified working Sonos .textClipping export.
+
+```xml
+<!-- Album art panel (one of two side-by-side) -->
+<PageElem type="dict">
+	<ActionGroup type="dict">
+		<ActionSteps type="vector">
+			<Action type="dict">
+				<Class type="integer">0</Class>
+				<ObjVers type="integer">14</ObjVers>
+			</Action>
+		</ActionSteps>
+		<ObjVers type="integer">2</ObjVers>
+	</ActionGroup>
+	<ControlType type="integer">101</ControlType>
+	<ImageFileURL type="string">file:///Library/Application%20Support/Perceptive%20Automation/images/Sonos/Study_art.jpg</ImageFileURL>
+	<ImageRefreshDuration type="integer">4000</ImageRefreshDuration>
+	<ObjVers type="integer">9</ObjVers>
+	<Position type="string">11 40</Position>
+	<ShowStateImage type="bool">true</ShowStateImage>
+	<ShowStateText type="bool">false</ShowStateText>
+	<Size type="string">500 500</Size>
+	<TargetElemSubKey type="string">sensorValue</TargetElemSubKey>
+</PageElem>
+```
+
+**Key points:**
+- Two 500x500 art panels side-by-side in a 1200x704 page (x=11 and x=600)
+- URL-encoded spaces in path (`%20`)
+- Images served from Indigo's own Application Support directory
+- Media transport buttons (ControlType 1/100 with Class 999 plugin actions) positioned below the art panels
+
+---
+
+## Layout Notes
+
+### Negative Positions
+
+Elements can use negative `Position` values. This is common for:
+- Fine-tuning image alignment (e.g., `0 -1` to nudge up by 1px)
+- Placing elements partially off-screen
+- Hiding elements that serve as data sources but don't need to be visible
+
+### Element Size vs Page Size
+
+- For full-screen image displays, set element `Size` equal to page `Size`
+- Elements can be larger than the page — they simply extend beyond the visible area
+- There is no auto-scaling; the image is displayed at the specified pixel dimensions
+
+### Image Formats
+
+External images support multiple formats:
+- `.png` — standard, supports transparency
+- `.jpg` / `.jpeg` — smaller file size, good for photos and camera feeds
+- The format is determined by the actual file, not the extension in the URL

--- a/docs/schema/actions.md
+++ b/docs/schema/actions.md
@@ -110,13 +110,13 @@ Controls sprinkler devices.
 
 ### Class 3: Thermostat Control
 
-Controls thermostat devices.
+Controls thermostat devices. Verified against working Heating .textClipping export.
 
 ```xml
 <Action type="dict">
   <Class type="integer">3</Class>
-  <DeviceID type="integer">DEVICE_ID</DeviceID>
-  <HVACAction type="integer">ACTION</HVACAction>
+  <DeviceID type="integer">1351833195</DeviceID>
+  <HVACAction type="integer">7</HVACAction>
   <ObjVers type="integer">14</ObjVers>
 </Action>
 ```
@@ -124,7 +124,7 @@ Controls thermostat devices.
 | Property | Type | Description |
 |----------|------|-------------|
 | `DeviceID` | integer | Thermostat device ID |
-| `HVACAction` | integer | HVAC action type |
+| `HVACAction` | integer | HVAC action type. `7` observed in working examples |
 | `HVACActionValue` | string | Optional. Temperature or mode value |
 
 ### Class 7: Speed Control
@@ -204,25 +204,26 @@ Sets or modifies an Indigo variable.
 
 ### Class 999: Plugin Action
 
-Executes a plugin-defined action.
+Executes a plugin-defined action. Verified against working Sonos .textClipping export.
 
 ```xml
 <Action type="dict">
   <Class type="integer">999</Class>
-  <MetaProps type="dict">
-    <!-- plugin-specific properties -->
-  </MetaProps>
+  <DeviceID type="integer">494584985</DeviceID>
   <ObjVers type="integer">14</ObjVers>
-  <PluginID type="string">com.example.plugin</PluginID>
-  <TypeIdPlugin type="string">actionTypeId</TypeIdPlugin>
+  <PluginID type="string">com.ssi.indigoplugin.Sonos</PluginID>
+  <TypeIdPlugin type="string">actionTogglePlay</TypeIdPlugin>
+  <TypeLabelPlugin type="string">Sonos: Toggle Play</TypeLabelPlugin>
 </Action>
 ```
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `PluginID` | string | Plugin bundle identifier |
-| `TypeIdPlugin` | string | Plugin action type ID |
-| `MetaProps` | dict | Plugin-specific action properties |
+| `DeviceID` | integer | Target device ID |
+| `PluginID` | string | Plugin bundle identifier (e.g., `com.ssi.indigoplugin.Sonos`) |
+| `TypeIdPlugin` | string | Plugin action type ID (e.g., `actionTogglePlay`, `actionStop`, `actionNext`, `actionPrevious`, `actionVolumeUp`, `actionVolumeDown`) |
+| `TypeLabelPlugin` | string | Human-readable action label (e.g., `Sonos: Toggle Play`) |
+| `MetaProps` | dict | Optional. Plugin-specific action properties |
 
 ---
 

--- a/docs/schema/control-page.md
+++ b/docs/schema/control-page.md
@@ -38,9 +38,10 @@ Multiple pages can be included in a single list for batch import.
 | Property | Type | Description |
 |----------|------|-------------|
 | `Category` | integer | Page category. Always `0` |
-| `Color` | string | Background color as space-separated hex pairs (e.g., `19 19 19` for dark) |
+| `Color` | string | Background color as space-separated hex pairs (e.g., `19 19 19` for dark). Optional — omit for no background color |
+| `DisplayInRemoteUI` | bool | Optional. Set to `false` to hide page from Indigo Touch and web clients. Defaults to `true` if omitted |
 | `ID` | integer | Unique page ID. Generate with `python3 -c "import random; print(random.randint(100000000, 2147483647))"` |
-| `ImageFileName` | string | Optional background image filename. Empty string for solid color |
+| `ImageFileName` | string | Optional background image from `Web Assets/images/backgrounds/`. Empty string or omit for solid color |
 | `Name` | string | Display name shown in Indigo's Control Pages list |
 | `ObjVers` | integer | Object version. Always `5` |
 | `Size` | string | Page dimensions as `"width height"` (e.g., `"375 667"`) |
@@ -56,9 +57,28 @@ Multiple pages can be included in a single list for batch import.
 | iPad Landscape | `1024 768` | Tablet landscape |
 | Full HD | `1920 1080` | Desktop / large display |
 
-## Background Images
+## Backgrounds
 
-Available from `Web Assets/images/backgrounds/`:
+### Solid Color Background
+
+Set the `Color` property to a space-separated hex pair. Omit `ImageFileName` or set it to `""`.
+
+```xml
+<Color type="string">19 19 19</Color>
+```
+
+Common background colors:
+
+| Color | Value | Use Case |
+|-------|-------|----------|
+| Dark (default) | `19 19 19` | Standard Indigo dark theme |
+| Slightly lighter | `2A 2A 2A` | Better contrast with dark icons |
+| Light gray | `CA CA CA` | Light theme, good for camera pages |
+| Black | `00 00 00` | OLED-friendly |
+
+### Background Image
+
+Set `ImageFileName` to a filename from `Web Assets/images/backgrounds/`:
 
 | Filename | Description |
 |----------|-------------|
@@ -67,7 +87,23 @@ Available from `Web Assets/images/backgrounds/`:
 | `floorplan3.png` | Floor plan background 3 |
 | `indigo_logo.png` | Indigo logo |
 
-Use empty string `""` for no background image (solid color only).
+### No Background (Full-Screen Image Pages)
+
+For pages that display a full-screen external image (ControlType 101), both `Color` and `ImageFileName` can be omitted entirely. The external image element covers the page. This is the pattern used by camera feeds and timetable displays.
+
+```xml
+<!-- No Color or ImageFileName — the full-screen image IS the background -->
+<ControlPage type="dict">
+	<Category type="integer">0</Category>
+	<ID type="integer">1624687364</ID>
+	<Name type="string">Camera Feed</Name>
+	<ObjVers type="integer">5</ObjVers>
+	<Size type="string">1024 600</Size>
+	<PageElemList type="vector">
+		<!-- ControlType 101 element fills entire page -->
+	</PageElemList>
+</ControlPage>
+```
 
 ## Critical XML Format Notes
 

--- a/docs/schema/enums.md
+++ b/docs/schema/enums.md
@@ -11,6 +11,7 @@ Element type determining behavior and rendering.
 | 1 | Device Control | Interactive device element (on/off, dimmer, thermostat) |
 | 2 | Variable/List | Variable display or list selection |
 | 100 | Button/Label | Static button or text label |
+| 101 | External Image | Image loaded from `file:///` URL with optional auto-refresh. See `docs/images/external-images.md` |
 | 200 | Text Display | Text-only display element |
 | 201 | Icon Indicator | Icon-based status indicator |
 
@@ -58,6 +59,16 @@ Colors are specified as space-separated hex pairs: `"RR GG BB"`
 | Dark gray | `33 33 33` | Dim/subtle text |
 | Black | `00 00 00` | Light background text |
 
+## HVACAction
+
+Action to perform on a thermostat (used in Class 3 actions).
+
+| Value | Action |
+|-------|--------|
+| 7 | Open thermostat control popup (observed in working examples) |
+
+> **Note:** Additional HVACAction values likely exist but have not been verified against working exports yet.
+
 ## DeviceAction
 
 Action to perform on a device (used in Class 1 actions).
@@ -100,6 +111,7 @@ Device state key to display. Which state property to monitor.
 | `setpointHeat` | Heating setpoint |
 | `hvacOperationMode` | Current HVAC mode |
 | `hvacFanMode` | Fan mode |
+| `heatIsOn` | Whether heating is currently active (used with Thermostat Heat Status image) |
 
 ### Sensor
 

--- a/docs/schema/page-elements.md
+++ b/docs/schema/page-elements.md
@@ -67,10 +67,14 @@ Every element on a control page is a `<PageElem type="dict">` inside the `<PageE
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `ImageFileName` | string | `""` | Image name WITH `.png` extension (e.g., `Dimmable Light 2x.png`). State suffixes added automatically by Indigo |
+| `ImageFileURL` | string | — | External image `file:///` URL. Used with ControlType 101 **instead of** `ImageFileName`. See `docs/images/external-images.md` |
+| `ImageRefreshDuration` | integer | — | Auto-refresh interval in milliseconds. Used with `ImageFileURL` (e.g., `1000` = 1s, `30000` = 30s) |
 | `ShowStateImage` | bool | `false` | Show state-dependent image (e.g., on/off variant) |
 | `ShowStateText` | bool | `false` | Show device state as text overlay on the image |
 
 **Image state behavior**: When `ShowStateImage` is true, Indigo automatically looks for state-suffixed images. For example, `Dimmable Light 2x.png` resolves to `Dimmable Light 2x+on.png` when the light is on.
+
+**External images**: ControlType 101 elements use `ImageFileURL` with `file:///` paths to load images from the local filesystem. Combined with `ImageRefreshDuration`, this creates live-updating displays for cameras, album art, timetables, etc. See `docs/images/external-images.md` for full details and examples.
 
 ### Caption Properties
 

--- a/skill.md
+++ b/skill.md
@@ -24,6 +24,7 @@ with ASCII wireframes, generates valid Indigo XML, and exports ready-to-import
 | WIREFRAME (designing layout) | `docs/layouts/templates.md`, `docs/layouts/sizing.md` |
 | BUILD (generating XML) | `docs/schema/control-page.md`, `docs/schema/page-elements.md`, `docs/schema/actions.md`, `docs/schema/enums.md` |
 | BUILD (choosing images) | `docs/images/device-images.md` |
+| BUILD (external/camera images) | `docs/images/external-images.md` |
 | EXPORT (creating file) | `docs/export/clipping-export.md` |
 
 ### Query Routing
@@ -40,6 +41,8 @@ with ASCII wireframes, generates valid Indigo XML, and exports ready-to-import
 | "What are the enum values?" | `docs/schema/enums.md` |
 | "Show me static images" | `docs/images/static-images.md` |
 | "Variable images?" | `docs/images/variable-images.md` |
+| "External images?" / "Camera feed" / "Auto-refresh image" | `docs/images/external-images.md` |
+| "Plugin actions?" / "Sonos controls" | `docs/schema/actions.md` (Class 999) |
 
 ## Workflow Overview
 
@@ -70,7 +73,8 @@ docs/
 ├── images/
 │   ├── device-images.md           # Device state images catalog
 │   ├── static-images.md           # Buttons, tiles, arrows
-│   └── variable-images.md         # Variable indicators
+│   ├── variable-images.md         # Variable indicators
+│   └── external-images.md         # External file:/// images with auto-refresh
 ├── layouts/
 │   ├── templates.md               # Pre-built room templates
 │   └── sizing.md                  # Screen sizes, spacing, grid


### PR DESCRIPTION
## Summary
- New `docs/images/external-images.md` covering ControlType 101 (file:/// images with auto-refresh)
- Updated action classes with verified examples (Class 3 HVAC, Class 999 Plugin)
- Added `DisplayInRemoteUI` page property and expanded background options
- Added `ImageFileURL`, `ImageRefreshDuration` to page element properties
- Added `.gitignore` for examples directory

All new content verified against 4 working .textClipping exports (Walton-Waterloo timetable, Drive Cam security camera, Sonos media controls, Heating thermostat).

## Test plan
- [ ] Verify new external-images.md examples match working exports
- [ ] Confirm skill routing loads external-images.md for relevant queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for external images with auto-refresh capability, enabling live-updating displays for security camera feeds and dynamic content
  * Introduced DisplayInRemoteUI property for control page configuration

* **Documentation**
  * Enhanced documentation for image properties, thermostat actions, and control page backgrounds
  * Added comprehensive examples and guidance for external image usage patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->